### PR TITLE
fix bug in name passed to GH REST API

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,7 @@ async function run() {
       release = await octokit.rest.repos.getReleaseByTag({ owner, repo, tag });
     } else if (!Number.isNaN(releaseId)) { // is numeric
       core.info(`Getting release ID: ${releaseId}`);
-      release = await octokit.rest.repos.getRelease({ owner, repo, releaseId });
+      release = await octokit.rest.repos.getRelease({ owner, repo, release_id: releaseId });
     } else if (!releaseId || releaseId === 'latest') {
       core.info('Getting latest release');
       release = await octokit.rest.repos.getLatestRelease({ owner, repo });


### PR DESCRIPTION
Fixes #10 
### Summary
`releaseId` was passed (and therefore the key), but it needs to be passed with a key of `release_id`